### PR TITLE
feat: change message submission to Enter key with Shift+Enter for new

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ release/*
 */dist/*
 *llmserver*
 *llmapp*
+.aider*

--- a/userinterface/src/components/ChatScreen.jsx
+++ b/userinterface/src/components/ChatScreen.jsx
@@ -329,7 +329,12 @@ export default function ChatScreen() {
   };
 
   const handleKeyPress = (e) => {
-    if (e.key === "Enter" && e.ctrlKey) {
+    if (e.key === "Enter" && e.shiftKey) {
+      // Allow default behavior for Shift+Enter (new line)
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
       handleSubmit(e);
     }
   };
@@ -406,7 +411,7 @@ export default function ChatScreen() {
           <HStack bg={"green.50"}>
             <Textarea
               isDisabled={waitingResponse}
-              placeholder="Enter your query here, Ctrl+Enter to send"
+              placeholder="Press Enter to send | Shift+Enter for new line"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={(e) => handleKeyPress(e)}


### PR DESCRIPTION
lines

Modify chat input handling to use Enter for submission and Shift+Enter for new lines for better cross-browser compatibility and user experience.

Fixes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Chat input behavior updated: users can now press **Enter** to send messages, with **Shift+Enter** allowing the insertion of a new line.
	- The placeholder text in the chat box has been revised to clearly indicate these key combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->